### PR TITLE
update fisco bcos provider code

### DIFF
--- a/examples/fisco-contract-call-service-provider/cmd/start.go
+++ b/examples/fisco-contract-call-service-provider/cmd/start.go
@@ -8,8 +8,8 @@ import (
 	"github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/common"
 	contractservice "github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/contract-service"
 	"github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/iservice"
-	"github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/store"
 	"github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/server"
+	"github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/store"
 )
 
 func StartCmd() *cobra.Command {
@@ -50,9 +50,15 @@ func StartCmd() *cobra.Command {
 			contractService.Logger = logger
 			appInstance := app.NewApp(iserviceClient, contractService, logger)
 
+			//set service name
+			appInstance.SetServiceName(config.GetString(common.ConfigKeyServiceName))
+
 			mysqlConfig := mysql.NewConfig(config)
 			mysql.NewDB(mysqlConfig)
 			defer mysql.Close()
+
+			// set test api handle
+			server.SetTestCallBack(contractService.Callback)
 
 			go server.StartWebServer(chainManager)
 			appInstance.Start()

--- a/examples/fisco-contract-call-service-provider/common/config.go
+++ b/examples/fisco-contract-call-service-provider/common/config.go
@@ -9,7 +9,11 @@ import (
 const (
 	DefaultConfigFileName = "./config/config.yaml"
 
-	ConfigKeyStorePath    = "base.store_path"
+	ConfigKeyStorePath = "base.store_path"
+
+	ConfigKeyServiceName = "service.service_name"
+
+	ConfigKeyNodes = "fisco.nodes"
 )
 
 // LoadYAMLConfig loads the YAML config file

--- a/examples/fisco-contract-call-service-provider/config/config.yaml
+++ b/examples/fisco-contract-call-service-provider/config/config.yaml
@@ -11,15 +11,21 @@ iservice:
   key_name: node0
   passphrase: 1234567890
 
+service:
+  service_name: cross_service_devtest
+
 # fisco config
 fisco:
+  chainId: 1
   connection_type: channel
   ca_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/ca.crt
   cert_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/sdk.crt
   key_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/sdk.key
   sm_crypto: true
   priv_key_file: /Users/bianjie/BSN/bsnhub-service-relayer/keys/key.pem
-
+  nodes:
+    fisco1.bsnbase.com: 192.168.1.72:20200
+    fisco2.bsnbase.com: 192.168.1.72:20201
 # mysql config
 mysql:
   db_name: relayer

--- a/examples/fisco-contract-call-service-provider/contract-service/fisco/chain.go
+++ b/examples/fisco-contract-call-service-provider/contract-service/fisco/chain.go
@@ -51,6 +51,7 @@ func (f *FISCOChain) InstantiateClient(
 
 	client, err := fiscoclient.Dial(clientConfig)
 	if err != nil {
+		common.Logger.Errorf("failed to connect to fisco node: %s", err)
 		return fmt.Errorf("failed to connect to fisco node: %s", err)
 	}
 

--- a/examples/fisco-contract-call-service-provider/iservice/config.go
+++ b/examples/fisco-contract-call-service-provider/iservice/config.go
@@ -35,12 +35,13 @@ const (
 
 // Config is a config struct for iservice
 type Config struct {
-	ChainID      string `yaml:"chain_id"`
-	NodeRPCAddr  string `yaml:"node_rpc_addr"`
-	NodeGRPCAddr string `yaml:"node_grpc_addr"`
-	KeyPath      string `yaml:"key_path"`
-	KeyName      string `yaml:"key_name"`
-	Passphrase   string `yaml:"passphrase"`
+	ChainID      string            `yaml:"chain_id"`
+	NodeRPCAddr  string            `yaml:"node_rpc_addr"`
+	NodeGRPCAddr string            `yaml:"node_grpc_addr"`
+	KeyPath      string            `yaml:"key_path"`
+	KeyName      string            `yaml:"key_name"`
+	Passphrase   string            `yaml:"passphrase"`
+	NodesMap     map[string]string `yaml:"nodes"`
 }
 
 // NewConfig constructs a new Config from viper

--- a/examples/fisco-contract-call-service-provider/mysql/db.go
+++ b/examples/fisco-contract-call-service-provider/mysql/db.go
@@ -13,19 +13,19 @@ var DB *sql.DB
 
 type table struct {
 	funique_id    int64
-	request_id    string         //请求唯一id
-	from_chainid  string         //起始链ID
-	from_tx       string         //起始链交易ID
-	hub_req_tx    string         //HUB请求交易ID
-	ic_request_id string         //HUB请求交易ID
-	to_chainid    string         //目标链ID
-	to_tx         *string         //目标链交易ID
-	hub_res_tx    string         //HUB响应交易ID
-	from_res_tx   *string         //向起始链响应数据的交易ID
-	tx_status     int         //交易状态
-	tx_time       *time.Time         //交易完成时间
-	tx_createtime time.Time         //交易创建时间
-	error         string        //交易异常
+	request_id    string     //请求唯一id
+	from_chainid  string     //起始链ID
+	from_tx       string     //起始链交易ID
+	hub_req_tx    string     //HUB请求交易ID
+	ic_request_id string     //HUB请求交易ID
+	to_chainid    string     //目标链ID
+	to_tx         *string    //目标链交易ID
+	hub_res_tx    string     //HUB响应交易ID
+	from_res_tx   *string    //向起始链响应数据的交易ID
+	tx_status     int        //交易状态
+	tx_time       *time.Time //交易完成时间
+	tx_createtime time.Time  //交易创建时间
+	error         string     //交易异常
 }
 
 // NewDB create a instance of the mysql db
@@ -63,7 +63,8 @@ func NewDB(mysqlConfig Config, options ...Option) {
 }
 
 func insert(field string, value string) error {
-	stmt, err := DB.Prepare("INSERT tb_irita_crosschain_tx SET " + field + "=?" + ", source_service = 1")
+
+	stmt, err := DB.Prepare("INSERT tb_irita_crosschain_tx SET " + field + "=?" + ", source_service = 1 ")
 	if err != nil {
 		return err
 	}
@@ -103,7 +104,8 @@ func update(field, value, icResID string) error {
 	return nil
 }
 func updateTime(field, icResID string) error {
-	cmd := fmt.Sprintf("UPDATE tb_irita_crosschain_tx SET %s=now() where request_id='%s'", field, icResID)
+	nowTime := time.Now().Format("2006-01-02 15:04:05")
+	cmd := fmt.Sprintf("UPDATE tb_irita_crosschain_tx SET %s='%s' where request_id='%s'", field, nowTime, icResID)
 	stmt, err := DB.Prepare(cmd)
 	if err != nil {
 		return err

--- a/examples/fisco-contract-call-service-provider/mysql/interchain.go
+++ b/examples/fisco-contract-call-service-provider/mysql/interchain.go
@@ -16,6 +16,12 @@ func OnServiceRequestReceived(icResID, toChainID string) {
 		common.Logger.Errorf(err.Error())
 		return
 	}
+
+	err = updateTime("tx_createtime", icResID)
+	if err != nil {
+		common.Logger.Errorf(err.Error())
+		return
+	}
 }
 
 // OnContractTxSend is the hook which is called when the request is sent to target chain
@@ -34,9 +40,14 @@ func OnInterchainResponseSent(icResID, hubResTx string) {
 		common.Logger.Errorf(err.Error())
 		return
 	}
+	err = update("tx_status", "1", icResID)
+	if err != nil {
+		common.Logger.Errorf(err.Error())
+		return
+	}
 }
 
-func TxErrCollection(icResID, errStr string){
+func TxErrCollection(icResID, errStr string) {
 	err := update("error", errStr, icResID)
 	if err != nil {
 		common.Logger.Errorf(err.Error())

--- a/examples/fisco-contract-call-service-provider/server/service.go
+++ b/examples/fisco-contract-call-service-provider/server/service.go
@@ -22,12 +22,12 @@ func NewChainManager(s *store.Store) *ChainManager {
 // AddChain adds a new app chain for the relayer
 func (cm *ChainManager) AddChain(params []byte) (chainID string, err error) {
 	chainID, err = types.GetChainIDFromBytes(params)
-	if err != nil{
+	if err != nil {
 		return "", err
 	}
-	chainIDsbz, _ :=cm.store.Get([]byte("chainIDs"))
+	chainIDsbz, _ := cm.store.Get([]byte("chainIDs"))
 	if chainIDsbz == nil {
-		chainIDsbz,err = json.Marshal(map[string]string{})
+		chainIDsbz, err = json.Marshal(map[string]string{})
 		if err != nil {
 			return "", err
 		}
@@ -35,10 +35,10 @@ func (cm *ChainManager) AddChain(params []byte) (chainID string, err error) {
 		if err != nil {
 			return "", err
 		}
-	}else{
-		chainIDMap:= map[string]bool{}
+	} else {
+		chainIDMap := map[string]bool{}
 		json.Unmarshal(chainIDsbz, &chainIDMap)
-		chainIDMap[chainID]= true
+		chainIDMap[chainID] = true
 		bz, err := json.Marshal(chainIDMap)
 		if err != nil {
 			return "", err
@@ -52,12 +52,12 @@ func (cm *ChainManager) AddChain(params []byte) (chainID string, err error) {
 	if err != nil {
 		return "", err
 	}
-	return chainID,nil
+	return chainID, nil
 }
 
 // GetChains gets all active app chains
-func (cm *ChainManager) GetChains() ([]string,error) {
-	chainIDMap:= map[string]bool{}
+func (cm *ChainManager) GetChains() ([]string, error) {
+	chainIDMap := map[string]bool{}
 	chainIDsbz, err := cm.store.Get([]byte("chainIDs"))
 	if err != nil {
 		return nil, err
@@ -67,8 +67,8 @@ func (cm *ChainManager) GetChains() ([]string,error) {
 		return nil, err
 	}
 	chainIDs := []string{}
-	for chainID, isexist := range chainIDMap{
-		if isexist{
+	for chainID, isexist := range chainIDMap {
+		if isexist {
 			chainIDs = append(chainIDs, chainID)
 		}
 	}
@@ -76,8 +76,8 @@ func (cm *ChainManager) GetChains() ([]string,error) {
 }
 
 // DeleteChain delete chain params by chain-id
-func (cm *ChainManager)DeleteChain(chainID string) (err error) {
-	chainIDMap:= map[string]bool{}
+func (cm *ChainManager) DeleteChain(chainID string) (err error) {
+	chainIDMap := map[string]bool{}
 	chainIDsbz, err := cm.store.Get([]byte("chainIDs"))
 	if err != nil {
 		return err
@@ -99,9 +99,9 @@ func (cm *ChainManager)DeleteChain(chainID string) (err error) {
 }
 
 // GetChainParams gets all chain params by chain-id
-func (cm *ChainManager)GetChainParams(chainID int64, groupID int) (config.ChainParams, error) {
+func (cm *ChainManager) GetChainParams(chainID int64) (config.ChainParams, error) {
 	var chainParams config.ChainParams
-	chainParamsBz, err := cm.store.Get([]byte(types.GetChainID(chainID, groupID)))
+	chainParamsBz, err := cm.store.Get([]byte(types.GetChainID(chainID)))
 	if err != nil {
 		return config.ChainParams{}, err
 	}

--- a/examples/fisco-contract-call-service-provider/types/types.go
+++ b/examples/fisco-contract-call-service-provider/types/types.go
@@ -1,22 +1,23 @@
 package types
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 	"github.com/bianjieai/bsnhub-service-demo/examples/fisco-contract-call-service-provider/contract-service/fisco/config"
+	"strconv"
 )
 
 const (
-	ServiceName = "fisco-contract-call"
+//ServiceName = "cross_service_dev"
 )
 
 type Input struct {
-	OptType         string `json:"opt_type"`
-	GroupID         int    `json:"group_id"`
+	OptType string `json:"opt_type"`
+	//GroupID         int    `json:"group_id"`
 	ChainID         int64  `json:"chain_id"`
 	ContractAddress string `json:"contract_address"`
 	CallData        string `json:"call_data"`
-	Height          uint64 `json:"height"`
+	//Height          uint64 `json:"height"`
 }
 
 type Output struct {
@@ -31,8 +32,13 @@ type Result struct {
 }
 
 // GetChainID returns the unique chain id from the specified chain params
-func GetChainID(chainID int64, groupID int) string {
-	return fmt.Sprintf("%s-%d-%d", "fisco", groupID, chainID)
+func GetChainIDString(chainID int64) string {
+	return strconv.FormatInt(chainID, 10)
+}
+
+func GetChainID(chainID int64) string {
+	//return strconv.FormatInt(chainID,10)
+	return fmt.Sprintf("%s-%d-%d", "fisco", 11, chainID)
 }
 
 // GetChainIDFromBytes returns the unique chain id from the given chain params bytes
@@ -43,5 +49,5 @@ func GetChainIDFromBytes(params []byte) (string, error) {
 		return "", err
 	}
 
-	return GetChainID(chainParams.ChainID, chainParams.GroupID), nil
+	return GetChainID(chainParams.ChainID), nil
 }


### PR DESCRIPTION
1. 增加配置的fisco节点名与节点地址映射配置以及服务名称配置
2. 增加连接fisco的chainId配置，不使用传递的chainId，这两个chainId不是同一个
3. 接口注册参数修改为节点名称列表
4. 修改路由规则，增加一个callback测试接口
5. 交易记录存储的chainId修改为注册的chanId的字符串格式
6. 交易记录存储增加创建时间
7. 跨链input取消GroupId以及height
8. AddChain直接使用bodybyte，不再使用绑定的JSON参数